### PR TITLE
Fix `after_commit, on: :update`

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -101,7 +101,9 @@ module ActiveRecord
               end.to_h
             )
 
-            unless affected_rows == 1
+            if affected_rows == 1
+              @_trigger_update_callback = true
+            else
               raise ActiveRecord::StaleObjectError.new(self, "update")
             end
 


### PR DESCRIPTION
The `after_commit on: :update` callbacks do not be fired when optimistic
locking enabled.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
